### PR TITLE
Add title to config to fix RSS feed

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,3 +1,4 @@
+title = "Boston BitDevs"
 base_url = "https://www.bostonbitdevs.org"
 compile_sass = false
 build_search_index = false


### PR DESCRIPTION
Currently the RSS feed is slightly broken because the `<title>` is empty.  Adding the `title` param to `config.toml` fixes this: <https://github.com/0xBEEFCAF3/bostonbitdevs/blob/c05b79aaae60/templates/feed.xml#L3>

before:

``` html
$ curl -s https://bostonbitdevs.org/feed.xml | head
<?xml version="1.0" encoding="UTF-8"?>
<feed xmlns="http://www.w3.org/2005/Atom" xml:lang="en">
    <title></title>
    <link href="https://www.bostonbitdevs.org/feed.xml" rel="self" type="application/atom+xml"/>
  <link href="https://www.bostonbitdevs.org"/>
    <generator uri="https://www.getzola.org/">Zola</generator>
    <updated>2022-10-26T00:00:00+00:00</updated>
    <id>https://www.bostonbitdevs.org/feed.xml</id>
    <entry xml:lang="en">
	    <title>Socratic Seminar 10</title>
```


after:

``` html
$ curl -s http://127.0.0.1:1111/feed.xml | head
<?xml version="1.0" encoding="UTF-8"?>
<feed xmlns="http://www.w3.org/2005/Atom" xml:lang="en">
    <title>Boston BitDevs</title>
    <link href="http://127.0.0.1:1111/feed.xml" rel="self" type="application/atom+xml"/>
  <link href="http://127.0.0.1:1111"/>
    <generator uri="https://www.getzola.org/">Zola</generator>
    <updated>2022-10-26T00:00:00+00:00</updated>
    <id>http://127.0.0.1:1111/feed.xml</id>
    <entry xml:lang="en">
	    <title>Socratic Seminar 10</title>
```