### PR TITLE
Socratic 12: add Swap-in-Potentiam and MAD Transactions

### DIFF
--- a/content/socratic-12.md
+++ b/content/socratic-12.md
@@ -13,24 +13,26 @@ aliases = ["socratic/2023/01/18/socratic-12.html"]
 
 ## lightning-dev
 
-- [A proposal for modifying the lightning channel protocol to introduce "Tunable Penalties"](https://github.com/JohnLaw2/ln-tunable-penalties/blob/main/tunablepenalties10.pdf)
-- [New lightning channel Factory construction proposals based on the above "Tunable Penalties" idea](https://lists.linuxfoundation.org/pipermail/lightning-dev/2022-December/003782.html)
-- [Circuitbreaker: an imperfect way to fight back against channel jamming](https://lists.linuxfoundation.org/pipermail/lightning-dev/2022-December/003781.html)
+- [A proposal for modifying the lightning channel protocol to introduce "Tunable Penalties"](https://github.com/JohnLaw2/ln-tunable-penalties/blob/main/tunablepenalties10.pdf) by John Law
+- [New lightning channel Factory construction proposals based on the above "Tunable Penalties" idea](https://lists.linuxfoundation.org/pipermail/lightning-dev/2022-December/003782.html) by jlspc
+- [Circuitbreaker: an imperfect way to fight back against channel jamming](https://lists.linuxfoundation.org/pipermail/lightning-dev/2022-December/003781.html) by Joost Jager
 - [LDK 113 - Ability to intercept HTLCs](https://github.com/lightningdevkit/rust-lightning/releases/tag/v0.0.113)
+- [Swap-in-Potentiam](https://lists.linuxfoundation.org/pipermail/lightning-dev/2023-January/003810.html) by Jesse Posner, ZmnSCPxj: Moving Onchain Funds "Instantly" To Lightning. A new proposal that enables bitcoin users with LSPs to receive to on-chain addresses/contracts constructed in a way that the on-chain funds can be used to instantly swap for lightning liquidity should the user want to in the future.
 
 ## Full-RBF Follow up
 
-- [Full-RBF December Statistics](https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2022-December/021296.html)
+- [Full-RBF December Statistics](https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2022-December/021296.html) by Peter Todd
+- [MAD Transactions](https://medium.com/@idBrain/mad-transactions-mutual-assured-destruction-transactions-c04f7b5a2fa7) by idBrain: A new 0-conf tx protocol proposal as a way to enable 0-conf txs in a full-rbf world. A game theoretical solution based on mutually assured destruction.
 
 ## Bitcoin Core
 
-- [BIP324 v2 P2P Transport Protocol PR merged](https://github.com/bitcoin/bips/pull/1378#event-8155389517)
+- [BIP324 v2 P2P Transport Protocol PR merged](https://github.com/bitcoin/bips/pull/1378#event-8155389517) - [https://bip324.com](https://bip324.com)
 
 ## bitcoin-dev
 
 - [ZeroSync - verify Bitcoin's chain state in an instant with a compact cryptographic proof](https://zerosync.org/)
 - [OP_VAULT - Vaults and Covenants](https://jameso.be/vaults.pdf)
-- [BIP-329 - A standard for importing wallet labels](https://github.com/bitcoin/bips/blob/master/bip-0329.mediawiki)
+- [BIP-329 merged](https://github.com/bitcoin/bips/blob/master/bip-0329.mediawiki): A standard for importing wallet labels
 
 ## Misc
 


### PR DESCRIPTION
Add Swap-in-Potentiam and MAD Transactions to Socratic 12 reading list

Since these two things popped up in the open issue for January topics, I figure we want to add them.