### PR TITLE
Add section for upcoming events

### DIFF
--- a/templates/home.html
+++ b/templates/home.html
@@ -15,7 +15,24 @@
   The reading lists for Socratic Seminars 1-8 can be found in the <a href="https://www.meetup.com/boston-bitdevs/events/past/" target="_blank">past events</a> section of the Meetup page.
 </p>
 
-<h2>Socratic Seminars</h2>
+<h2>RSVP for upcoming events</h2>
+
+<ul class="posts">
+  <li>
+    TBD Mar 2025 » Socratic Seminar 28
+  </li>
+  <li>
+    03 Apr 2025 » <a href="https://evento.so/p/evt_yYwEjZFAAkBMAGL9">Socratic Seminar 29</a>
+  </li>
+  <li>
+    17 Jul 2025 » <a href="https://evento.so/p/evt_y4ZsA1hFJjwqPneL">Socratic Seminar 30</a>
+  </li>
+  <li>
+    13 Nov 2025 » <a href="https://evento.so/p/evt_ZBhnKr2ne7AcZCqp">Socratic Seminar 31</a>
+  </li>
+</ul>
+
+<h2>Socratic Seminar Reading Lists</h2>
 <ul class="posts">
   {% for page in section.pages %}
   <li>

--- a/templates/index.html
+++ b/templates/index.html
@@ -36,7 +36,7 @@
     <footer>
       <span>
         Sponsored by
-        <a href="https://www.fcatalyst.com/overview">the Fidelity Center for Applied Technology</a> and <a href="https://cequals.xyz/">c=</a>
+        <a href="https://www.fcatalyst.com/overview">the Fidelity Center for Applied Technology</a>
       </span>
     </footer>
   </body>


### PR DESCRIPTION
I'm worried about losing people with the move from Meetup to Evento so I made this PR to add links to our Evento events on the Boston BitDevs home page. 

This is going to be annoying to maintain so I'm working on longer term solution: a dedicated Boston BitDevs page in Evento that lists all our upcoming events. That way we can just swap out the "Meetup" link in the header of the page. But for now, I want to make sure the Evento links are as visible as possible.

Note: I tried to make a separate page for this list of upcoming events but couldn't figure out the correct, non-hacky way to do it. After I gave up I realized I probably wanted this list on the home page anyway, for maximum visibility.

I also removed c= from the sponsor list :( Will make an exciting new PR soon with 2025 sponsors!

Screenshot of what the changes look like:
![Screenshot from 2025-02-19 21-15-15](https://github.com/user-attachments/assets/0b59a2c1-b64d-4a4b-9923-d18561d6375b)
