### PR TITLE
Fix numbering for upcoming socratic. Update sponsors.

### DIFF
--- a/bin/check-links
+++ b/bin/check-links
@@ -28,7 +28,7 @@ links=(
   socratic/2025/09/30/socratic-31.html
   socratic/2025/11/13/socratic-32.html
   socratic/2026/01/22/socratic-33.html
-  socratic/2026/04/10/socratic-35.html
+  socratic/2026/04/10/socratic-34.html
 )
 
 for link in ${links[@]}; do

--- a/content/socratic-34.md
+++ b/content/socratic-34.md
@@ -1,7 +1,7 @@
 +++
-title = "Socratic Seminar 35"
+title = "Socratic Seminar 34"
 date = 2026-04-10
-aliases = ["socratic/2026/04/10/socratic-35.html"]
+aliases = ["socratic/2026/04/10/socratic-34.html"]
 +++
 
 ## Housekeeping 🧹

--- a/templates/home.html
+++ b/templates/home.html
@@ -19,7 +19,7 @@
 
 <ul class="posts">
   <li>
-    10 April 2026 » <a href="https://app.evento.so/e/evt_7Xb4jPnRNT1iQzpA">Socratic Seminar 35</a>
+    10 April 2026 » <a href="https://app.evento.so/e/evt_7Xb4jPnRNT1iQzpA">Socratic Seminar 34</a>
   </li>
 </ul>
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -27,12 +27,9 @@
   <hr />
   <footer>
     <span>
-      Sponsored by
-      <a href="https://www.fcatalyst.com/overview">the Fidelity Center for Applied Technology</a>, <a
-        href="https://www.timestampfinancial.com/">Timestamp</a>, <a href="https://bvcannabis.com/">Blackstone Valley
-        Cannabis</a>, <a href="https://joltz.app/">Joltz</a>, and <a
-        href="https://www.microsoftnewengland.com/">Microsoft
-        New England</a>.
+      Sponsored by the 
+      <a href="https://www.fcatalyst.com/overview">Fidelity Center for Applied Technology</a>, <a href="https://bvcannabis.com/">Blackstone Valley
+        Cannabis</a>, and the <a href="https://bitcoin.mit.edu/">MIT Bitcoin Club</a>.
     </span>
   </footer>
 </body>


### PR DESCRIPTION
We [never ended up having a March event](https://github.com/arminsabouri/bostonbitdevs/issues/46) so this upcoming socratic seminar on Friday is actually number 34. I fixed it in Evento and am now updating it here.

Also updated the sponsor list to reflect current sponsors.