### PR TITLE
soc 35: fix link

### DIFF
--- a/templates/home.html
+++ b/templates/home.html
@@ -19,10 +19,7 @@
 
 <ul class="posts">
   <li>
-    10 April 2026 » <a href="https://app.evento.so/e/evt_7Xb4jPnRNT1iQzpA">Socratic Seminar 34 @ Fidelity</a>
-  </li> 
-  <li>
-    June 2026 (Date TBD) » <a href="https://evento.so/p/evt_ZJKdHJEEq6hSpqau">Socratic Seminar 35 @ MIT</a>
+    30 July 2026 » <a href="https://app.evento.so/e/evt_3M48gmwDKdbzNc63">Socratic Seminar 35 @ MIT</a>
   </li>
   <li>
     13 August 2026 » <a href="https://evento.so/p/evt_9fcVYNxo5QdEzThb">Socratic Seminar 36 @ Fidelity</a>


### PR DESCRIPTION
I had to make a new Evento page I think because the old page didn't have a date. This PR fixes the link for that and removes socratic 34 from the list of upcoming events